### PR TITLE
Stale old admin router

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,23 @@ This extension expands core Magento functionality for order status management.
 
 # Compatibility
 
-- Magento >= 1.6 (tested for 1.9.1)
+- Magento >= 1.6 (tested for 1.9.3.10)
 
 # Copyright
 
 (c) 2015 devdl
+
+# The original module seems abandoned 
+PR: https://github.com/devdl/MEC_ChangeOrderStatus/pull/2 has not been merged for over a year.
+
+I have clients who actively use this module, so I forked this and will add any fixes etc here.
+
+Fixed:
+
+1.0.0 : Remove old admin router definition
+1.0.1 : Permisisons are wrong. If user is not admin role (all perms) they cannot change order status. The module exposes 'MEC Change Order Status' permisisons, so code was adjusted to use that value when set in role perms
+
+
 
 
 

--- a/app/code/community/MEC/ChangeOrderStatus/controllers/Adminhtml/ChangeorderstatusController.php
+++ b/app/code/community/MEC/ChangeOrderStatus/controllers/Adminhtml/ChangeorderstatusController.php
@@ -48,4 +48,9 @@ class MEC_ChangeOrderStatus_Adminhtml_ChangeorderstatusController extends Mage_A
         $this->_redirect('/sales_order/');        
         
     }
+    
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('system/config/changeorderstatus');
+    }
 }

--- a/app/code/community/MEC/ChangeOrderStatus/etc/adminhtml.xml
+++ b/app/code/community/MEC/ChangeOrderStatus/etc/adminhtml.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<config>
+    <acl>
+        <resources>
+            <all>
+                <title>Allow Everything</title>
+            </all>
+            <admin>
+                <children>
+                    <system>
+                        <children>
+                            <config>
+                                <children>
+                                    <changeorderstatus>
+                                        <title>MEC Change Order Status</title>
+                                    </changeorderstatus>
+                                </children>
+                            </config>
+                        </children>
+                    </system>
+                </children>
+            </admin>
+        </resources>
+    </acl>
+</config>

--- a/app/code/community/MEC/ChangeOrderStatus/etc/config.xml
+++ b/app/code/community/MEC/ChangeOrderStatus/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <MEC_ChangeOrderStatus>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </MEC_ChangeOrderStatus>
     </modules>
     <global>

--- a/app/code/community/MEC/ChangeOrderStatus/etc/config.xml
+++ b/app/code/community/MEC/ChangeOrderStatus/etc/config.xml
@@ -81,13 +81,6 @@
                     </modules>
                 </args>
             </adminhtml>
-            <changeorderstatus>
-                <use>admin</use>
-                <args>
-                    <module>MEC_ChangeOrderStatus</module>
-                    <frontName>admin_changeorderstatus</frontName>
-                </args>
-            </changeorderstatus>
         </routers>
     </admin>    
     <adminhtml>        

--- a/app/code/community/MEC/ChangeOrderStatus/etc/config.xml
+++ b/app/code/community/MEC/ChangeOrderStatus/etc/config.xml
@@ -92,26 +92,7 @@
                     </files>
                 </Osmibit_Erpsync>
             </modules>
-        </translate>        
-        <acl>
-            <resources>
-                <admin>
-                    <children>
-                        <system>
-                            <children>
-                                <config>
-                                    <children>
-                                        <changeorderstatus>
-                                            <title>MEC Change Order Status</title>
-                                        </changeorderstatus>
-                                    </children>
-                                </config>
-                            </children>
-                        </system>
-                    </children>
-                </admin>
-            </resources>
-        </acl>    
+        </translate>
     </adminhtml>       
     <default>
         <changeorderstatus>


### PR DESCRIPTION
Remove old admin router definition from code. The updated admin router is already present.